### PR TITLE
Don't mess with left or right margins on group blocks

### DIFF
--- a/wp-content/themes/caribbean/blocks/caribbean-group-block-fact-box/style.css
+++ b/wp-content/themes/caribbean/blocks/caribbean-group-block-fact-box/style.css
@@ -1,7 +1,8 @@
 .wp-block-group.is-style-fact-box {
     border: 3px solid #D34400;
     padding: 0 10%;
-    margin: 3.5rem 0;
+    margin-top: 3.5rem;
+    margin-bottom: 3.5rem;
 }
 .wp-block-group.is-style-fact-box h2 {
     width: max-content;


### PR DESCRIPTION
## Changes

This pull request makes the following changes:

- removes a CSS property setting left and right margins on the fact box style of Group block, because that was overriding the margins used on `.alignwide` and `.alignfull`

Before:
![Screen Shot 2019-12-03 at 21 02 30](https://user-images.githubusercontent.com/1754187/70105977-6ea7cd00-1610-11ea-9ecb-2bfcd45e8e43.png)

After:
![Screen Shot 2019-12-03 at 21 01 55](https://user-images.githubusercontent.com/1754187/70105986-75364480-1610-11ea-8d6e-3d881a24e675.png)

## Why

<!-- Why does this PR propose these changes? Take as much space as you need to explain. -->
<!-- If there are GitHub issues that this pull request addresses, please list them here. -->
For #19 

## Testing/Questions

Features that this PR affects:

- The Group Block's fact-box style

<!-- If there are no questions, please remove the questions section. -->
Questions that need to be answered before merging:

- [ ] Is this PR targeting the correct branch in this repository?
- [ ] works?

Steps to test this PR:

1. create a post with two group blocks with the "Fact Box" style chosen, one aligned wide and one aligned full