### PR TITLE
Bandaid fix to grab 100 posts per page

### DIFF
--- a/wp-content/themes/caribbean/blocks/caribbean-post-selector-block/index.js
+++ b/wp-content/themes/caribbean/blocks/caribbean-post-selector-block/index.js
@@ -100,7 +100,7 @@ function (_Component) {
     value: function getOptions() {
       var _this2 = this;
 
-      return new wp.api.collections.Posts().fetch().then(function (posts) {
+      return new wp.api.collections.Posts().fetch( { data: { per_page: 100 } } ).then(function (posts) {
         if (posts && 0 !== _this2.state.selectedPost) {
           // If we have a selected Post, find that post and add it.
           var post = posts.find(function (item) {


### PR DESCRIPTION
## Changes

This pull request makes the following changes:

- Adds `{ data: { per_page: 100 } }` argument to the `wp.api.collections` for the post selector block as a bandaid. And no, `per_page: -1` is not an option 😢 

## Why

<!-- Why does this PR propose these changes? Take as much space as you need to explain. -->
<!-- If there are GitHub issues that this pull request addresses, please list them here. -->
For #78, because apparently `wp.api.collections.Posts().fetch()` defaults to `per_page: 10` and that's no good

## Testing/Questions

Features that this PR affects:

- Post selector block

<!-- If there are no questions, please remove the questions section. -->
Questions that need to be answered before merging:

- [ ] Is this PR targeting the correct branch in this repository?

Steps to test this PR:

1. Make sure you have more than 10 posts on your site
2. Make sure all of them (if you have <100) show up in the post selector autocomplete